### PR TITLE
If there is no database, the database is excluded

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -68,6 +68,10 @@ func TestPool_Get(t *testing.T) {
 		}
 	})
 	t.Run("found", func(t *testing.T) {
+		_, err := pool.Create(ctx, spoolSpannerDatabaseNamePrefix())
+		if err != nil {
+			t.Fatal(err)
+		}
 		if _, err := pool.Get(ctx); err != nil {
 			t.Fatal(err)
 		}

--- a/pool_test.go
+++ b/pool_test.go
@@ -3,6 +3,7 @@ package spool
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -110,12 +111,17 @@ func TestPool_GetOrCreate(t *testing.T) {
 	}
 
 	t.Run("get", func(t *testing.T) {
-		got, err := pool.GetOrCreate(ctx, spoolSpannerDatabaseNamePrefix())
+		dbNamePrefix := fmt.Sprintf("%s-get", spoolSpannerDatabaseNamePrefix()) // Adjusted names to avoid collisions
+		_, err := pool.Create(ctx, dbNamePrefix)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got.DatabaseName != sdb.DatabaseName {
-			t.Errorf("expected %s but got %s", sdb.DatabaseName, got.DatabaseName)
+		got, err := pool.GetOrCreate(ctx, dbNamePrefix)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(got.DatabaseName, dbNamePrefix) {
+			t.Errorf("expected %s prefix but got %s", dbNamePrefix, got.DatabaseName)
 		}
 	})
 	t.Run("create", func(t *testing.T) {

--- a/pool_test.go
+++ b/pool_test.go
@@ -2,6 +2,7 @@ package spool
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/spanner"
@@ -68,7 +69,7 @@ func TestPool_Get(t *testing.T) {
 		}
 	})
 	t.Run("found", func(t *testing.T) {
-		_, err := pool.Create(ctx, spoolSpannerDatabaseNamePrefix())
+		_, err := pool.Create(ctx, fmt.Sprintf("%s-found", spoolSpannerDatabaseNamePrefix())) // Adjusted names to avoid collisions
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pool_test.go
+++ b/pool_test.go
@@ -119,7 +119,7 @@ func TestPool_GetOrCreate(t *testing.T) {
 		}
 	})
 	t.Run("create", func(t *testing.T) {
-		got, err := pool.GetOrCreate(ctx, spoolSpannerDatabaseNamePrefix())
+		got, err := pool.GetOrCreate(ctx, fmt.Sprintf("%s-create", spoolSpannerDatabaseNamePrefix())) // Adjusted names to avoid collisions
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pool_test.go
+++ b/pool_test.go
@@ -37,7 +37,7 @@ func TestPool_Create(t *testing.T) {
 }
 
 func TestPool_Get(t *testing.T) {
-	t.Parallel()
+	// t.Parallel() // this test can't be parallel because it uses time.Now().Unix()
 
 	cfg := SetupTestDatabase(t)
 


### PR DESCRIPTION
# WHAT

When the database is deleted from outside, the name of a non-existent database is returned, so we added an existence check.

# WHY

When CI crashes and cleanup fails, the database remains, so when the process to delete them is performed, consistency can be lost.